### PR TITLE
Add covid-19 community support fund back to ongoing projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,6 @@
         matching up to $10,000 in donations to Bay Area organizations working
         for racial justice across a variety of issues.
       </li>
-    </ul>
-
-    <h6>Past</h6>
-    <ul>
       <li>
         <strong>COVID-19 Community Support Fund</strong>:
         zero-interest loans for people facing financial difficulties because of


### PR DESCRIPTION
Now that we're restarted the covid-19 community support fund it should live under Ongoing Projects and the Past projects section doesn't need to exist.